### PR TITLE
Initialize 'chosen' pointer in z_log_msg_claim_oldest to NULL

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -695,7 +695,7 @@ union log_msg_generic *z_log_msg_local_claim(void)
 union log_msg_generic *z_log_msg_claim_oldest(k_timeout_t *backoff)
 {
 	union log_msg_generic *msg = NULL;
-	struct log_msg_ptr *chosen;
+	struct log_msg_ptr *chosen = NULL;
 	log_timestamp_t t_min = sizeof(log_timestamp_t) > sizeof(uint32_t) ?
 				UINT64_MAX : UINT32_MAX;
 	int i = 0;


### PR DESCRIPTION
Fixes a compiler warning that the variable may be uninitialized when later dereferenced. The way the method is written, it would never be uninitialized if msg is uninitialized, but the compiler does not seem to make that inference.